### PR TITLE
Implement fixture based tests, grouped via class for ~Particle

### DIFF
--- a/plasmapy/atomic/tests/test_particle_class.py
+++ b/plasmapy/atomic/tests/test_particle_class.py
@@ -566,30 +566,33 @@ def test_particle_bool_error():
     with pytest.raises(AtomicError):
         bool(Particle('e-'))
 
+@pytest.fixture(params=ParticleZoo.everything)
+def particle(request):
+    return Particle(request.param)
 
-def test_particle_inversion():
+@pytest.fixture()
+def opposite(particle):
+    try:
+        opposite_particle = ~particle
+    except Exception:
+        raise InvalidParticleError(
+                "The unary operator is unable to find the antiparticle "
+                f"of {particle}.")
+    return opposite_particle
+
+class Test__particle_inversion():
     """
     Test that the unary operator finds the antiparticle of all special
     particles and antiparticles.
     """
-
-    for particle_symb in ParticleZoo.everything:
-
-        particle = Particle(particle_symb)
-
-        try:
-            opposite = ~particle
-        except Exception:
-            raise InvalidParticleError(
-                "The unary operator is unable to find the antiparticle "
-                f"of {particle}.")
-
+    def test_opposite_charge(self, particle, opposite):
         assert particle.integer_charge == -opposite.integer_charge, \
             (f"The charges of {particle} and {opposite} are not "
              f"opposites, which indicates that there is a problem "
              f"using the unary operator to find the antiparticle of "
              f"{particle}.")
 
+    def test_equal_mass(self, particle, opposite):
         assert particle._attributes['mass'] == opposite._attributes['mass'], \
             (f"The masses of {particle} and {opposite} are not equal, "
              f"which indicates that there is a problem using the unary "


### PR DESCRIPTION
This PR attempts to solve the problem that we're still writing sequential tests with multiple `assert`s within one functional block, and those are a pain to find and debug issues within those

Here, let me show you why this approach is nicer:
```bash
(plasmapy) [~/Code/PlasmaPy]$ pytest -k 'inversion' plasmapy/atomic/tests/test_particle_class.py -v
======================================================================================================================================= test session starts =======================================================================================================================================
platform linux -- Python 3.6.2, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /home/dominik/.anaconda3/envs/plasmapy/bin/python
cachedir: .cache
rootdir: /home/dominik/Code/PlasmaPy, inifile: setup.cfg
plugins: doctestplus-0.1.2, cov-2.5.1
collected 97 items                                                                                                                                                                                                                                                                                

plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_opposite_charge[anti_nu_e] PASSED                                                                                                                                                                              [  3%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_opposite_charge[p-] PASSED                                                                                                                                                                                     [  6%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_opposite_charge[nu_tau] PASSED                                                                                                                                                                                 [  9%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_opposite_charge[anti_nu_mu] PASSED                                                                                                                                                                             [ 12%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_opposite_charge[antineutron] PASSED                                                                                                                                                                            [ 15%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_opposite_charge[mu+] PASSED                                                                                                                                                                                    [ 18%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_opposite_charge[nu_e] PASSED                                                                                                                                                                                   [ 21%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_opposite_charge[p+] PASSED                                                                                                                                                                                     [ 25%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_opposite_charge[e-] PASSED                                                                                                                                                                                     [ 28%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_opposite_charge[tau+] PASSED                                                                                                                                                                                   [ 31%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_opposite_charge[nu_mu] PASSED                                                                                                                                                                                  [ 34%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_opposite_charge[anti_nu_tau] PASSED                                                                                                                                                                            [ 37%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_opposite_charge[tau-] PASSED                                                                                                                                                                                   [ 40%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_opposite_charge[e+] PASSED                                                                                                                                                                                     [ 43%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_opposite_charge[n] PASSED                                                                                                                                                                                      [ 46%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_opposite_charge[mu-] PASSED                                                                                                                                                                                    [ 50%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_equal_mass[anti_nu_e] PASSED                                                                                                                                                                                   [ 53%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_equal_mass[p-] PASSED                                                                                                                                                                                          [ 56%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_equal_mass[nu_tau] PASSED                                                                                                                                                                                      [ 59%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_equal_mass[anti_nu_mu] PASSED                                                                                                                                                                                  [ 62%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_equal_mass[antineutron] PASSED                                                                                                                                                                                 [ 65%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_equal_mass[mu+] PASSED                                                                                                                                                                                         [ 68%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_equal_mass[nu_e] PASSED                                                                                                                                                                                        [ 71%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_equal_mass[p+] PASSED                                                                                                                                                                                          [ 75%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_equal_mass[e-] PASSED                                                                                                                                                                                          [ 78%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_equal_mass[tau+] PASSED                                                                                                                                                                                        [ 81%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_equal_mass[nu_mu] PASSED                                                                                                                                                                                       [ 84%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_equal_mass[anti_nu_tau] PASSED                                                                                                                                                                                 [ 87%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_equal_mass[tau-] PASSED                                                                                                                                                                                        [ 90%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_equal_mass[e+] PASSED                                                                                                                                                                                          [ 93%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_equal_mass[n] PASSED                                                                                                                                                                                           [ 96%]
plasmapy/atomic/tests/test_particle_class.py::Test__particle_inversion::test_equal_mass[mu-] PASSED                                                                                                                                                                                         [100%]

======================================================================================================================================= 65 tests deselected =======================================================================================================================================
============================================================================================================================ 32 passed, 65 deselected in 2.88 seconds =============================================================================================================================
```

I'm really geeking out hard over this. :smiley: 