### PR TITLE
Action towncrier changelog

### DIFF
--- a/.github/workflows/add-no-changelog-label.yml
+++ b/.github/workflows/add-no-changelog-label.yml
@@ -1,8 +1,8 @@
-name: Label PR
+name: Changelog
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened, edited]
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
 
 jobs:
   no-changelog:
@@ -47,3 +47,12 @@ jobs:
               labels: ['No changelog entry needed'],
             });
           }
+
+  changelog-checker:
+    name: Validate towncrier changelog entry
+    runs-on: ubuntu-latest
+    steps:
+    - uses: scientific-python/action-towncrier-changelog@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BOT_USERNAME: changelog-bot

--- a/.github/workflows/add-no-changelog-label.yml
+++ b/.github/workflows/add-no-changelog-label.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, edited, labeled, unlabeled]
 
 jobs:
-  no-changelog:
+  add-no-changelog-label:
     name: Add no changelog label
     runs-on: ubuntu-latest
     permissions:
@@ -51,6 +51,7 @@ jobs:
   changelog-checker:
     name: Validate towncrier changelog entry
     runs-on: ubuntu-latest
+    needs: add-no-changelog-label
     steps:
     - uses: scientific-python/action-towncrier-changelog@v1
       env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,22 +260,14 @@ ue,
 ue,
 windo"""
 
-[tool.gilesbot]
-
-[tool.gilesbot.pull_requests]
+[tool.changelog-bot]
+[tool.changelog-bot.towncrier_changelog]
 enabled = true
-
-[tool.gilesbot.towncrier_changelog]
-enabled = true
-changelog_skip_label = "no changelog entry needed"
-help_url = "https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
-changelog_missing = "Missing changelog entry (see `changelog/README.rst`)"
-changelog_missing_long = "Please add a changelog entry at `changelog/NUMBER.TYPE.rst`, where `NUMBER` is the pull request number and `TYPE` is one of `feature`, `trivial`, `doc`, `internal`, `bugfix`, `breaking`, or `removal`.\n\nMinor pull requests, such as typo fixes and hyperlink updates, do not need a changelog entry.\n\nFor details, see: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
 verify_pr_number = true
-number_incorrect = "Changelog entry number ≠ PR number (see `changelog/README.rst`)"
-number_incorrect_long = "The changelog entry number does not match this pull request's number.\n\nWhen purposefully editing the changelog entry for a different pull request, set the 'no changelog entry needed' label to ignore this check."
-type_incorrect = "Incorrect changelog type (see `changelog/README.rst`)"
-type_incorrect_long = "The filename of the changelog entry must be of the form `changelog/NUMBER.TYPE.rst` where `TYPE` is one of `feature`, `trivial`, `doc`, `internal`, `bugfix`, `breaking`, or `removal`.\n\nFor details, see: https://docs.plasmapy.org/en/latest/contributing/changelog_guide.html#adding-a-changelog-entry"
+changelog_skip_label = "no changelog entry needed"
+changelog_noop_label = "skip changelog checks"
+whatsnew_label = "needs changelog entry"
+whatsnew_pattern = '''changelog\/\d+\.\d+\.rst'''
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request (PR) to PlasmaPy — we really appreciate it!

Please include a descriptive title above (e.g., "Add function to calculate gyroradius") and fill out the relevant sections below.

Please feel free to chat with other contributors at: https://app.element.io/#/room/#plasmapy:openastronomy.org

We also have a contributor guide at: https://docs.plasmapy.org/en/latest/contributing/index.html
-->

## Description

<!-- Please summarize the changes here. -->



## Motivation and context

<!-- Please describe the reasons for making this pull request. This section may be skipped for minor changes. -->



## Related issues

<!-- Please link to any related issues and PRs. If this PR will fully resolve and issue, include text like "Closes #1542" so that the issue will be automatically closed when this PR is merged. -->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the GitHub Actions workflow to add a new job for validating towncrier changelog entries and extends the trigger events to include labeled and unlabeled events.

- **CI**:
    - Updated the GitHub Actions workflow to include a new job for validating towncrier changelog entries.
    - Extended the trigger events for the workflow to include labeled and unlabeled events.

<!-- Generated by sourcery-ai[bot]: end summary -->